### PR TITLE
Fix API PhEntryF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Nothing yet
+
+## 2.6.1
+
+- Fix new API for `PhEntryF`/`PhEntryDistF`. [#28](https://github.com/tzaeschke/phtree/pull/28)
+
+## 2.6.0
+
 - CHANGELOG.md [#26](https://github.com/tzaeschke/phtree/pull/26)
 - Added new multimap: PhTreeMultiMapF2. [#23](https://github.com/tzaeschke/phtree/pull/23)
 - Added CI with GitHub actions. [#25](https://github.com/tzaeschke/phtree/pull/25)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In 2019 and 2020 development was kindly supported by [Improbable](https://improb
 <dependency>
     <groupId>ch.ethz.globis.phtree</groupId>
     <artifactId>phtree</artifactId>
-    <version>2.6.0</version>
+    <version>2.6.1</version>
 </dependency>
 ```
 
@@ -47,6 +47,7 @@ You can create GitHub Issues or contact me on [Discord](https://discord.gg/GNYjy
 # News
 
 ### 2023-06-26
+Release 2.6.0 / 2.6.1
 - Added new multimap: `PhTreeMultiMapF2`.
 
 ### 2020-04-30

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,9 +1,19 @@
+API
+===
+- Change APIs to always use common PhEntryF and PhEntryDistF. -> PhTreeF + PhTreeMultiMapF
+- Compile with Java 17 or 20!!! -> Faster!
+
+Impl
+====
+- Simplify minMask/maxMask calculation. -> see issue tracker
+- Use min/max heap for kNN
 - Not optimal: all iterators locate the 'next' element before returning a current element (true?).
   This is inefficient because there a lot of iterators in a stack. Especially problematic when 
   returning nearest neighbor.
+  -> Consider different type of iterator that does not extent Iterator<T>???? E>g. w/o hasNext() ?
 - Not optimal: When reading NT-Nodes, the tree always applies valTemplate/hcPos etc to the result
   kdKey, even though the kdKey is already complete  
-- The node iterators should now the global min/maxRange to efficiently check kdKeys without
+- The node iterators should know the global min/maxRange to efficiently check kdKeys without
   popping out of the local iterators and then popping in again if it is a mismatch.
   
 - NodeIteratorFull: remove applying valTemplate from readingNt keys (for-loop in readValue).  

--- a/src/main/java/ch/ethz/globis/phtree/PhEntryDistF.java
+++ b/src/main/java/ch/ethz/globis/phtree/PhEntryDistF.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2011-2016 ETH Zurich. All Rights Reserved.
+ *
+ * This software is the proprietary information of ETH Zurich.
+ * Use is subject to license terms.
+ */
+package ch.ethz.globis.phtree;
+
+import java.util.Comparator;
+
+/**
+ * An entry with additional distance, used for returning results from nearest neighbour queries.
+ * 
+ * @param <T> The value type
+ */
+public class PhEntryDistF<T> extends PhEntryF<T> {
+	public static final Comparator<PhEntryDistF<?>> COMP =
+			(PhEntryDistF<?> o1, PhEntryDistF<?> o2) -> {
+			//We assume only normal positive numbers
+			//We have to do it this way because the delta may exceed the 'int' value space
+			double d = o1.dist - o2.dist;
+			return d > 0 ? 1 : (d < 0 ? -1 : 0);
+		};
+
+	private double dist;
+
+	public PhEntryDistF(double[] key, T value, double dist) {
+		super(key, value);
+		this.dist = dist;
+	}
+
+	/**
+	 * Copy constructor.
+	 * @param e entry to copy
+	 * @param dist the distance value
+	 */
+	public PhEntryDistF(PhEntryF<T> e, double dist) {
+		super(e);
+		this.dist = dist;
+	}
+
+	/**
+	 * Copy constructor.
+	 * @param e entry to copy
+	 */
+	public PhEntryDistF(PhEntryDistF<T> e) {
+		super(e);
+		this.dist = e.dist();
+	}
+
+	public void setCopyKey(double[] key, T val, double dist) {
+		System.arraycopy(key, 0, getKey(), 0, getKey().length);
+		set(val, dist);
+	}
+
+	public void set(PhEntryF<T> e, double dist) {
+		super.setValue(e.getValue());
+		System.arraycopy(e.getKey(), 0, getKey(), 0, getKey().length);
+		this.dist = dist;
+	}
+	
+	public void set(T val, double dist) {
+		super.setValue(val);
+		this.dist = dist;
+	}
+
+	public void clear() {
+		dist = Double.MAX_VALUE;
+	}
+	
+	public double dist() {
+		return dist;
+	}
+
+	public void setDist(double dist) {
+		this.dist = dist;
+	}
+	
+	@Override
+	public String toString() {
+		return super.toString() + " dist=" + dist;
+	}
+}

--- a/src/main/java/ch/ethz/globis/phtree/PhEntryF.java
+++ b/src/main/java/ch/ethz/globis/phtree/PhEntryF.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2011-2016 ETH Zurich. All Rights Reserved.
+ *
+ * This software is the proprietary information of ETH Zurich.
+ * Use is subject to license terms.
+ */
+package ch.ethz.globis.phtree;
+
+import java.util.Arrays;
+
+/**
+ * Entry class for Double entries.
+ *
+ * @param <T> value type of the entries
+ */
+public class PhEntryF<T> {
+	private double[] key;
+	private T value;
+	public PhEntryF(double[] key, T value) {
+		this.key = key;
+		this.value = value;
+	}
+
+	public PhEntryF(PhEntryF<T> e) {
+		this.key = Arrays.copyOf(e.getKey(), e.getKey().length);
+		this.value = e.getValue();
+	}
+	
+	public double[] getKey() {
+		return key;
+	}
+	
+	public T getValue() {
+		return value;
+	}
+
+	protected void set(double[] key, T value) {
+		this.key = key;
+		this.value = value;
+	}
+	
+	protected void setKeyRef(double[] key) {
+		this.key = key;
+	}
+
+    @SuppressWarnings("unchecked")
+	@Override
+    public boolean equals(Object o) {
+        if (this == o) {
+        	return true;
+        }
+        if (!(o instanceof PhEntryF)) {
+        	return false;
+        }
+
+        PhEntryF<T> pvEntry = (PhEntryF<T>) o;
+
+        if (!Arrays.equals(key, pvEntry.key)) {
+        	return false;
+        }
+        if (value != null ? !value.equals(pvEntry.value) : pvEntry.value != null) {
+        	return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = key != null ? Arrays.hashCode(key) : 0;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        return result;
+    }
+
+	public void setValue(T value) {
+		this.value = value;
+	}
+	
+	@Override
+	public String toString() {
+		return Arrays.toString(key) + " -> " + value;
+	}
+}

--- a/src/main/java/ch/ethz/globis/phtree/PhTreeMultiMapF2.java
+++ b/src/main/java/ch/ethz/globis/phtree/PhTreeMultiMapF2.java
@@ -54,8 +54,8 @@ public class PhTreeMultiMapF2<T> {
     public static final int DEFAULT_SIZE = 2;
     private final PhTree<Object> pht;
     private final PreProcessorPointF pre;
-    private int size = 0;
     private final ObjectPool<ArrayList<T>> pool = ObjectPool.create(10, () -> new ArrayList<>(DEFAULT_SIZE));
+    private int size = 0;
 
     protected PhTreeMultiMapF2(int dim, PreProcessorPointF pre) {
         this.pht = PhTree.create(dim);
@@ -244,7 +244,7 @@ public class PhTreeMultiMapF2<T> {
      * @param center Center point
      * @return All entries with at most distance `dist` from `center`.
      */
-    public PhRangeQueryMMF<T> rangeQuery(double dist, double... center) {
+    public PhRangeQueryF<T> rangeQuery(double dist, double... center) {
         return rangeQuery(dist, PhDistanceF.THIS, center);
     }
 
@@ -256,14 +256,14 @@ public class PhTreeMultiMapF2<T> {
      * @param center       Center point
      * @return All entries with at most distance `dist` from `center`.
      */
-    public PhRangeQueryMMF<T> rangeQuery(double dist, PhDistance optionalDist, double... center) {
+    public PhRangeQueryF<T> rangeQuery(double dist, PhDistance optionalDist, double... center) {
         if (optionalDist == null) {
             optionalDist = PhDistanceF.THIS;
         }
         long[] lKey = new long[center.length];
         pre.pre(center, lKey);
         PhRangeQuery<Object> iter = pht.rangeQuery(dist, optionalDist, lKey);
-        return new PhRangeQueryMMF<>(iter, pht, pre);
+        return new PhRangeQueryF<>(iter, pht, pre);
     }
 
     public int getDim() {
@@ -278,11 +278,11 @@ public class PhTreeMultiMapF2<T> {
      * @param key  the center point
      * @return List of neighbours.
      */
-    public PhKnnQueryMMF<T> nearestNeighbour(int nMin, double... key) {
+    public PhKnnQueryF<T> nearestNeighbour(int nMin, double... key) {
         long[] lKey = new long[key.length];
         pre.pre(key, lKey);
         PhKnnQuery<Object> iter = pht.nearestNeighbour(nMin, PhDistanceF.THIS, null, lKey);
-        return new PhKnnQueryMMF<>(iter, pht.getDim(), pre);
+        return new PhKnnQueryF<>(iter, pht.getDim(), pre);
     }
 
     /**
@@ -295,11 +295,11 @@ public class PhTreeMultiMapF2<T> {
      * @param key  the center point
      * @return KNN query iterator.
      */
-    public PhKnnQueryMMF<T> nearestNeighbour(int nMin, PhDistance dist, double... key) {
+    public PhKnnQueryF<T> nearestNeighbour(int nMin, PhDistance dist, double... key) {
         long[] lKey = new long[key.length];
         pre.pre(key, lKey);
         PhKnnQuery<Object> iter = pht.nearestNeighbour(nMin, dist, null, lKey);
-        return new PhKnnQueryMMF<>(iter, pht.getDim(), pre);
+        return new PhKnnQueryF<>(iter, pht.getDim(), pre);
     }
 
     /**
@@ -537,7 +537,7 @@ public class PhTreeMultiMapF2<T> {
      *
      * @param <T> value type
      */
-    public static class PhIteratorMMF<T> implements PhIteratorBase<T, PhEntryF<T>> {
+    public static class PhIteratorF<T> implements PhIteratorBase<T, PhEntryF<T>> {
         protected final PreProcessorPointF pre;
         private final PhIteratorBase<Object, ? extends PhEntry<Object>> iter;
         private final PhEntryF<T> buffer;
@@ -547,7 +547,7 @@ public class PhTreeMultiMapF2<T> {
         private ArrayList<T> currentList;
         private int pos = Integer.MAX_VALUE;
 
-        protected PhIteratorMMF(PhIteratorBase<Object, ? extends PhEntry<Object>> iter, int dims, PreProcessorPointF pre) {
+        protected PhIteratorF(PhIteratorBase<Object, ? extends PhEntry<Object>> iter, int dims, PreProcessorPointF pre) {
             this.iter = iter;
             this.pre = pre;
             this.buffer = new PhEntryF<>(new double[dims], null);
@@ -624,7 +624,7 @@ public class PhTreeMultiMapF2<T> {
             throw new UnsupportedOperationException();
         }
 
-        protected PhIteratorMMF<T> reset() {
+        protected PhIteratorF<T> reset() {
             pos = Integer.MAX_VALUE;
             findNextInternal();
             return this;
@@ -642,7 +642,7 @@ public class PhTreeMultiMapF2<T> {
      *
      * @param <T> value type
      */
-    public static class PhExtentMMF<T> extends PhIteratorMMF<T> {
+    public static class PhExtentMMF<T> extends PhIteratorF<T> {
         private final PhExtent<Object> iter;
 
         protected PhExtentMMF(PhExtent<Object> iter, int dims, PreProcessorPointF pre) {
@@ -668,7 +668,7 @@ public class PhTreeMultiMapF2<T> {
      *
      * @param <T> value type
      */
-    public static class PhQueryMMF<T> extends PhIteratorMMF<T> {
+    public static class PhQueryMMF<T> extends PhIteratorF<T> {
         private final long[] lMin;
         private final long[] lMax;
         private final PhQuery<Object> q;
@@ -699,7 +699,7 @@ public class PhTreeMultiMapF2<T> {
      *
      * @param <T> value type
      */
-    public static class PhKnnQueryMMF<T> implements PhIteratorBase<T, PhEntryDistF<T>> {
+    public static class PhKnnQueryF<T> implements PhIteratorBase<T, PhEntryDistF<T>> {
         private final PreProcessorPointF pre;
         private final PhKnnQuery<Object> iter;
         private final PhEntryDistF<T> buffer;
@@ -708,7 +708,7 @@ public class PhTreeMultiMapF2<T> {
         private ArrayList<T> currentList;
         private int pos = Integer.MAX_VALUE;
 
-        protected PhKnnQueryMMF(PhKnnQuery<Object> iter, int dims, PreProcessorPointF pre) {
+        protected PhKnnQueryF(PhKnnQuery<Object> iter, int dims, PreProcessorPointF pre) {
             this.iter = iter;
             this.pre = pre;
             this.buffer = new PhEntryDistF<>(new double[dims], null, Double.NaN);
@@ -797,7 +797,7 @@ public class PhTreeMultiMapF2<T> {
          * @param center new center point
          * @return this
          */
-        public PhKnnQueryMMF<T> reset(int nMin, PhDistance dist, double[] center) {
+        public PhKnnQueryF<T> reset(int nMin, PhDistance dist, double[] center) {
             pos = Integer.MAX_VALUE;
             long[] lCenter = new long[center.length];
             pre.pre(center, lCenter);
@@ -812,11 +812,11 @@ public class PhTreeMultiMapF2<T> {
      *
      * @param <T> value type
      */
-    public static class PhRangeQueryMMF<T> extends PhIteratorMMF<T> {
+    public static class PhRangeQueryF<T> extends PhIteratorF<T> {
         private final long[] lCenter;
         private final PhRangeQuery<Object> q;
 
-        protected PhRangeQueryMMF(PhRangeQuery<Object> iter, PhTree<Object> tree, PreProcessorPointF pre) {
+        protected PhRangeQueryF(PhRangeQuery<Object> iter, PhTree<Object> tree, PreProcessorPointF pre) {
             super(iter, tree.getDim(), pre);
             this.q = iter;
             this.lCenter = new long[tree.getDim()];
@@ -829,7 +829,7 @@ public class PhTreeMultiMapF2<T> {
          * @param center new center point
          * @return this
          */
-        public PhRangeQueryMMF<T> reset(double range, double... center) {
+        public PhRangeQueryF<T> reset(double range, double... center) {
             pre.pre(center, lCenter);
             q.reset(range, lCenter);
             super.reset();

--- a/src/test/java/ch/ethz/globis/phtree/test/TestMultiMapF2.java
+++ b/src/test/java/ch/ethz/globis/phtree/test/TestMultiMapF2.java
@@ -7,6 +7,7 @@
 package ch.ethz.globis.phtree.test;
 
 import ch.ethz.globis.phtree.PhDistanceF;
+import ch.ethz.globis.phtree.PhEntryDistF;
 import ch.ethz.globis.phtree.PhTreeMultiMapF2;
 import ch.ethz.globis.phtree.PhTreeMultiMapF2.*;
 import ch.ethz.globis.phtree.util.BitTools;
@@ -215,7 +216,7 @@ public class TestMultiMapF2 {
         idx.put(new double[]{1, 3}, new double[]{1, 3});
         idx.put(new double[]{3, 1}, new double[]{3, 1});
 
-        List<PhEntryDistMMF<double[]>> result = toList(idx.nearestNeighbour(0, 3, 3));
+        List<PhEntryDistF<double[]>> result = toList(idx.nearestNeighbour(0, 3, 3));
         assertTrue(result.isEmpty());
 
         result = toList(idx.nearestNeighbour(3, 2, 2));
@@ -235,18 +236,6 @@ public class TestMultiMapF2 {
         result = toList(idx.nearestNeighbour(1, 3, 1));
         assertTrue(1 <= result.size());
         check(result.get(0).getKey(), 3, 1);
-    }
-
-    private static class EntryDist<T> {
-        double[] key;
-        T value;
-        double dist;
-
-        public EntryDist(double[] key, T v, double dist) {
-            this.key = key;
-            this.value = v;
-            this.dist = dist;
-        }
     }
 
     @Test
@@ -271,13 +260,13 @@ public class TestMultiMapF2 {
                 }
                 for (int dupl = 0; dupl <= i % N_DUPL; dupl++) {
                     ind.put(v, id);
-                    list.add(new EntryDist<>(v,id, 0 ));
+                    list.add(new EntryDist<>(v, id, 0));
                     id++;
                 }
             }
             assertEquals(id, ind.size());
 
-            PhKnnQueryMMF<Integer> q = ind.nearestNeighbour(MIN_RESULT, new double[DIM]);
+            PhKnnQueryF<Integer> q = ind.nearestNeighbour(MIN_RESULT, new double[DIM]);
             for (int i = 0; i < NQ; i++) {
                 double[] v = new double[DIM];
                 for (int j = 0; j < DIM; j++) {
@@ -285,7 +274,7 @@ public class TestMultiMapF2 {
                 }
                 list.forEach(xx -> xx.dist = dist(v, xx.key));
                 list.sort((o1, o2) -> Double.compare(o1.dist, o2.dist));
-                List<PhEntryDistMMF<Integer>> nnList = toList(q.reset(MIN_RESULT, PhDistanceF.THIS, v));
+                List<PhEntryDistF<Integer>> nnList = toList(q.reset(MIN_RESULT, PhDistanceF.THIS, v));
                 assertFalse("i=" + i + " d=" + d, nnList.isEmpty());
                 for (int x = 0; x < MIN_RESULT; ++x) {
                     assertEquals(list.get(x).dist, nnList.get(x).dist(), 0.0);
@@ -386,14 +375,14 @@ public class TestMultiMapF2 {
         final Random R = new Random(0);
         for (int d = 0; d < LOOP; d++) {
             PhTreeMultiMapF2<Integer> ind = newTree(DIM);
-            PhRangeQueryMMF<Integer> q = ind.rangeQuery(1, PhDistanceF.THIS, new double[DIM]);
+            PhRangeQueryF<Integer> q = ind.rangeQuery(1, PhDistanceF.THIS, new double[DIM]);
             for (int i = 0; i < N; i++) {
                 double[] v = new double[DIM];
                 for (int j = 0; j < DIM; j++) {
                     v[j] = R.nextDouble() * MAXV;
                 }
-                ind.put(v, 2*i);
-                ind.put(v, 2*i + 1);
+                ind.put(v, 2 * i);
+                ind.put(v, 2 * i + 1);
             }
             for (int i = 0; i < NQ; i++) {
                 double[] v = new double[DIM];
@@ -411,7 +400,7 @@ public class TestMultiMapF2 {
 
     private ArrayList<double[]> rangeQuery(PhTreeMultiMapF2<?> tree, double range, double[] q) {
         ArrayList<double[]> points = new ArrayList<>();
-        PhIteratorMMF<?> i = tree.queryExtent();
+        PhIteratorF<?> i = tree.queryExtent();
         while (i.hasNext()) {
             double[] cand = i.nextEntry().getKey();
             double dNew = dist(q, cand);
@@ -454,7 +443,7 @@ public class TestMultiMapF2 {
         }
     }
 
-    private List<double[]> toList(PhRangeQueryMMF<?> q) {
+    private List<double[]> toList(PhRangeQueryF<?> q) {
         ArrayList<double[]> ret = new ArrayList<>();
         while (q.hasNext()) {
             ret.add(q.nextEntry().getKey());
@@ -462,14 +451,14 @@ public class TestMultiMapF2 {
         return ret;
     }
 
-    private <T> List<PhEntryDistMMF<T>> toList(PhKnnQueryMMF<T> q) {
-        ArrayList<PhEntryDistMMF<T>> ret = new ArrayList<>();
+    private <T> List<PhEntryDistF<T>> toList(PhKnnQueryF<T> q) {
+        ArrayList<PhEntryDistF<T>> ret = new ArrayList<>();
         while (q.hasNext()) {
             if (ret.size() % 2 == 0) {
                 ret.add(q.nextEntry());
             } else {
-                PhEntryDistMMF<T> e = q.nextEntryReuse();
-                ret.add(new PhEntryDistMMF<>(e.getKey().clone(), e.getValue(), e.dist()));
+                PhEntryDistF<T> e = q.nextEntryReuse();
+                ret.add(new PhEntryDistF<>(e.getKey().clone(), e.getValue(), e.dist()));
             }
         }
         return ret;
@@ -481,5 +470,17 @@ public class TestMultiMapF2 {
             l[i] = BitTools.toSortableLong(d[i]);
         }
         return Bits.toBinary(l);
+    }
+
+    private static class EntryDist<T> {
+        double[] key;
+        T value;
+        double dist;
+
+        public EntryDist(double[] key, T v, double dist) {
+            this.key = key;
+            this.value = v;
+            this.dist = dist;
+        }
     }
 }


### PR DESCRIPTION
Fix API to have one common class for each of `PhEntryF`/`PhEntryDistF` .

This PR does not actually fix this for `PhTreeF` and `PhTreeMultiMapF` but it provides these classes and fixes it for `PhTreeMultiMapF2`.